### PR TITLE
Tiny fix of giscus component in post.ejs

### DIFF
--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -17,7 +17,7 @@
           <div class="post-content"><%- page.content %></div
 
         </article>
-        <% if (theme.giscus.enable) { %>
+        <% if (theme.giscus && theme.giscus.enable) { %>
         <script src="https://giscus.app/client.js"
           data-repo=  <%= theme.giscus.repo %>
           data-repo-id="MDEwOlJlcG9zaXRvcnkzNTIwMzg4MTk="


### PR DESCRIPTION
fixes a rendering issue when giscus is misconfigured or set to false. now possible to render post pages without giscus